### PR TITLE
Feature/QA-6173 - Run changed test specs+smokes in PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
           namespace: false
 
     - name: Run Cypress not snapshot tests on Currents.dev
-      run: currents run --config baseUrl=${{ inputs.customEnv == '' && inputs.url ||  inputs.customEnv }} --tag ${{ inputs.env }} --spec ${{ inputs.spec_file }} --env ${{ inputs.tags }} --browser chrome --record --parallel --key ${{ inputs.record_key }} --ci-build-id "${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt}}"
+      run: currents run --config baseUrl=${{ inputs.customEnv == '' && inputs.url ||  inputs.customEnv }} --tag ${{ inputs.env }} --spec ${{ inputs.spec_file }} --env ${{ inputs.tags }} --browser chrome --record --parallel --key ${{ inputs.record_key }} --ci-build-id "${{ github.repository }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt}}"
       shell: bash  
       env:
         CYPRESS_USERNAME: ${{ inputs.USERNAME }}


### PR DESCRIPTION
Added `github.job` for Cypress' `ci-build-id` to create different id's for Dashboard, so we could record all runs.

**NOTE:** When PR will be merged - update tag to latest so we can use this in our codebase