### PR TITLE
[QA-6347] TestOps - GH Action improvements and fixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
           ${{ runner.os }}-
 
     - name: Install Dependencies
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       uses: bahmutov/npm-install@v1
       run: npm t
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
         ref: ${{ inputs.ref }}
 
     - name: Install Dependencies
-      uses: bahmutov/npm-install@v1
+      uses: bahmutov/npm-install@latest
 
     - name: Install Cypress globally
       run: npm i cypress@10.3.1 -g

--- a/action.yml
+++ b/action.yml
@@ -71,16 +71,16 @@ runs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Cache node modules
+    - name: Install Dependencies
+      run: npm install
+      shell: bash
+
+    - name: Install Cypress globally
       run: npm i cypress@10.3.1 -g
       shell: bash
     
     - name: Install Currents globally
       run: npm i @currents/cli -g
-      shell: bash
-
-    - name: Install Dependencies
-      run: npm install
       shell: bash
 
     - name: Configure secrets

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,6 @@ runs:
       uses: actions/checkout@v3
       uses: bahmutov/npm-install@v1
       run: npm t
-      shell: bash
 
     - name: Install Cypress globally
       run: npm i cypress@10.3.1 -g

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,9 @@ runs:
           ${{ runner.os }}-
 
     - name: Install Dependencies
-      run: npm install
+      uses: actions/checkout@v2
+      uses: bahmutov/npm-install@v1
+      run: npm t
       shell: bash
 
     - name: Install Cypress globally

--- a/action.yml
+++ b/action.yml
@@ -58,19 +58,6 @@ runs:
         token: ${{ inputs.github_token }}
         ref: ${{ inputs.ref }}
 
-    - name: Cache node modules
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
     - name: Install Dependencies
       uses: actions/checkout@v3
       uses: bahmutov/npm-install@v1

--- a/action.yml
+++ b/action.yml
@@ -59,9 +59,7 @@ runs:
         ref: ${{ inputs.ref }}
 
     - name: Install Dependencies
-      uses: actions/checkout@v3
       uses: bahmutov/npm-install@v1
-      run: npm t
 
     - name: Install Cypress globally
       run: npm i cypress@10.3.1 -g


### PR DESCRIPTION
## Description
[QA-6347](https://bowery.atlassian.net/browse/QA-6347) Change steps with npm install to usage of next action: [GitHub - bahmutov/npm-install: GitHub Action for install npm dependencies with caching without any configuration](https://github.com/bahmutov/npm-install) . This will require changes in several places (pull_request_check.yml or custom action).

## Screenshots:
![image](https://user-images.githubusercontent.com/47743960/185147748-6f01d10c-a25b-490d-80df-6e67fcc9478d.png)