### PR TITLE
[QA-6415] TestOps - Github PRs + End-to-end integration - Action update (new secrets, new image, new checks)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,17 +57,13 @@ runs:
         repository: 'Bowery-RES/webapp-ui-automation'
         token: ${{ inputs.github_token }}
         ref: ${{ inputs.ref }}
-
-    # - name: Install Cypress globally
-    #   run: npm i cypress@10.3.1 -g --unsafe-perm
-    #   shell: bash
     
-    - name: Install Currents globally
-      run: npm i @currents/cli -g --unsafe-perm
-      shell: bash
-
     - name: Install Dependencies
-      uses: bahmutov/npm-install@v1.8.21
+      uses: bahmutov/npm-install@v1.8.21    
+
+    - name: Install Currents globally
+      run: npm i @currents/cli -g
+      shell: bash
 
     - name: Configure secrets
       if: ${{ !env.ACT }} 
@@ -83,6 +79,8 @@ runs:
           secrets: |
             Github/Cypress/User_Roles
             Github/Cypress/Launch_Darkly
+            Github/Cypress/Data_Dog_Api_Key
+            Github/Cypress/Current_Dev_Record_Key
           namespace: false
 
 

--- a/action.yml
+++ b/action.yml
@@ -70,12 +70,14 @@ runs:
       shell: bash
 
     - name: Configure secrets
+      if: ${{ !env.ACT }} 
       uses: aws-actions/configure-aws-credentials@v1
       with:
           role-to-assume: arn:aws:iam::814827541967:role/GithubOIDC-Role-QMKR3DR5WV3B
           aws-region: 'us-east-1'
 
     - name: Set secrets to GH environment
+      if: ${{ !env.ACT }} 
       uses: Bowery-RES/action-aws-secrets@v1.2
       with:
           secrets: |

--- a/action.yml
+++ b/action.yml
@@ -4,12 +4,6 @@ inputs:
   github_token:
     description: 'Github token'
     required: false
-  username:
-    description: "Username for test run"
-    required: true
-  password: 
-    description: "Password for Username"
-    required: true
   url:
     description: "Name of the test url (dev, staging, prod, custom)"
     required: true
@@ -25,9 +19,6 @@ inputs:
     description: "Tags for cypress-grep"
     required: true
     default: grep=,grepTags=@smoke,burn=
-  record_key:
-    description: "record key used to activate test results recording on Dashboard"
-    required: true
   grep_filter_specs:
     description: "Skip test specs when using cypress-grep from tag retrieve"
     required: false
@@ -44,12 +35,10 @@ runs:
       shell: bash
       run: |
           echo "github_token=${{ inputs.github_token }}"
-          echo "username=${{ inputs.USERNAME }}"
           echo "url=${{ inputs.url }}"
           echo "customUrl=${{ inputs.customUrl }}"
           echo "spec_file=${{ inputs.spec_file }}"
           echo "tags=${{ inputs.tags }}"
-          echo "record_key=${{ inputs.record_key }}"
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -83,14 +72,10 @@ runs:
             Github/Cypress/Current_Dev_Record_Key
           namespace: false
 
-
-
     - name: Run Cypress not snapshot tests on Currents.dev
-      run: currents run --config-file cypress.config.ts --tag ${{ inputs.url }} --spec ${{ inputs.spec_file }} --env ${{ inputs.tags }} --browser chrome --record --parallel --key ${{ inputs.record_key }} --ci-build-id "${{ github.repository }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt}}"
+      run: currents run --config-file cypress.config.ts --tag ${{ inputs.url }} --spec ${{ inputs.spec_file }} --env ${{ inputs.tags }} --browser chrome --record --parallel --key ${{ env.CYPRESS_CURRENTS_RECORD_KEY }} --ci-build-id "${{ github.repository }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt}}"
       shell: bash  
       env:
-        CYPRESS_USERNAME: ${{ inputs.USERNAME }}
-        CYPRESS_PASSWORD: ${{ inputs.PASSWORD }}
         CYPRESS_url: ${{ inputs.url }}
         CYPRESS_customUrl: ${{ inputs.customUrl == '' && '' ||  inputs.customUrl }}
         CYPRESS_grepFilterSpecs: ${{ inputs.grep_filter_specs }}

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
             Github/Cypress/User_Roles
             Github/Cypress/Launch_Darkly
           namespace: false
-          
+
     - name: Show action's inputs
       shell: bash
       run: |
@@ -78,11 +78,11 @@ runs:
       uses: bahmutov/npm-install@v1.8.21
 
     - name: Install Cypress globally
-      run: npm i cypress@10.3.1 -g
+      run: npm i cypress@10.3.1 -g --unsafe-perm --silent
       shell: bash
     
     - name: Install Currents globally
-      run: npm i @currents/cli -g
+      run: npm i @currents/cli -g --unsafe-perm --silent
       shell: bash
 
 

--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,9 @@ runs:
         token: ${{ inputs.github_token }}
         ref: ${{ inputs.ref }}
 
-    - name: Install Cypress globally
-      run: npm i cypress@10.3.1 -g --unsafe-perm
-      shell: bash
+    # - name: Install Cypress globally
+    #   run: npm i cypress@10.3.1 -g --unsafe-perm
+    #   shell: bash
     
     - name: Install Currents globally
       run: npm i @currents/cli -g --unsafe-perm

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,22 @@ runs:
   using: "composite"
   steps:
 
+    - name: Configure secrets
+      if: ${{ !env.ACT }} 
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+          role-to-assume: arn:aws:iam::814827541967:role/GithubOIDC-Role-QMKR3DR5WV3B
+          aws-region: 'us-east-1'
+
+    - name: Set secrets to GH environment
+      if: ${{ !env.ACT }} 
+      uses: Bowery-RES/action-aws-secrets@v1.2
+      with:
+          secrets: |
+            Github/Cypress/User_Roles
+            Github/Cypress/Launch_Darkly
+          namespace: false
+          
     - name: Show action's inputs
       shell: bash
       run: |
@@ -69,21 +85,7 @@ runs:
       run: npm i @currents/cli -g
       shell: bash
 
-    - name: Configure secrets
-      if: ${{ !env.ACT }} 
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-          role-to-assume: arn:aws:iam::814827541967:role/GithubOIDC-Role-QMKR3DR5WV3B
-          aws-region: 'us-east-1'
 
-    - name: Set secrets to GH environment
-      if: ${{ !env.ACT }} 
-      uses: Bowery-RES/action-aws-secrets@v1.2
-      with:
-          secrets: |
-            Github/Cypress/User_Roles
-            Github/Cypress/Launch_Darkly
-          namespace: false
 
     - name: Run Cypress not snapshot tests on Currents.dev
       run: currents run --config-file cypress.config.ts --tag ${{ inputs.url }} --spec ${{ inputs.spec_file }} --env ${{ inputs.tags }} --browser chrome --record --parallel --key ${{ inputs.record_key }} --ci-build-id "${{ github.repository }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt}}"

--- a/action.yml
+++ b/action.yml
@@ -57,13 +57,13 @@ runs:
         repository: 'Bowery-RES/webapp-ui-automation'
         token: ${{ inputs.github_token }}
         ref: ${{ inputs.ref }}
-        
+
     - name: Install Cypress globally
-      run: npm i cypress@10.3.1 -g --unsafe-perm --silent
+      run: npm i cypress@10.3.1 -g --unsafe-perm
       shell: bash
     
     - name: Install Currents globally
-      run: npm i @currents/cli -g --unsafe-perm --silent
+      run: npm i @currents/cli -g --unsafe-perm
       shell: bash
 
     - name: Install Dependencies

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   spec_file:
     description: "--spec flag arg in cypress cli"
     required: true
-    default: "cypress/integration/**/*.spec.ts"
+    default: cypress/integration/**
   tags:
     description: "Tags for cypress-grep"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -40,22 +40,6 @@ runs:
   using: "composite"
   steps:
 
-    - name: Configure secrets
-      if: ${{ !env.ACT }} 
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-          role-to-assume: arn:aws:iam::814827541967:role/GithubOIDC-Role-QMKR3DR5WV3B
-          aws-region: 'us-east-1'
-
-    - name: Set secrets to GH environment
-      if: ${{ !env.ACT }} 
-      uses: Bowery-RES/action-aws-secrets@v1.2
-      with:
-          secrets: |
-            Github/Cypress/User_Roles
-            Github/Cypress/Launch_Darkly
-          namespace: false
-
     - name: Show action's inputs
       shell: bash
       run: |
@@ -73,10 +57,7 @@ runs:
         repository: 'Bowery-RES/webapp-ui-automation'
         token: ${{ inputs.github_token }}
         ref: ${{ inputs.ref }}
-
-    - name: Install Dependencies
-      uses: bahmutov/npm-install@v1.8.21
-
+        
     - name: Install Cypress globally
       run: npm i cypress@10.3.1 -g --unsafe-perm --silent
       shell: bash
@@ -84,6 +65,25 @@ runs:
     - name: Install Currents globally
       run: npm i @currents/cli -g --unsafe-perm --silent
       shell: bash
+
+    - name: Install Dependencies
+      uses: bahmutov/npm-install@v1.8.21
+
+    - name: Configure secrets
+      if: ${{ !env.ACT }} 
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+          role-to-assume: arn:aws:iam::814827541967:role/GithubOIDC-Role-QMKR3DR5WV3B
+          aws-region: 'us-east-1'
+
+    - name: Set secrets to GH environment
+      if: ${{ !env.ACT }} 
+      uses: Bowery-RES/action-aws-secrets@v1.2
+      with:
+          secrets: |
+            Github/Cypress/User_Roles
+            Github/Cypress/Launch_Darkly
+          namespace: false
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   ref:
     description: "`ref` param for actions/checkout"
     required: false
+  secret_name:
+    description: "Name of the secret in aws secret manager"
+    required: false
 
 runs:
   using: "composite"
@@ -54,22 +57,13 @@ runs:
       run: npm i @currents/cli -g
       shell: bash
 
-    - name: Configure secrets
-      if: ${{ !env.ACT }} 
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-          role-to-assume: arn:aws:iam::814827541967:role/GithubOIDC-Role-QMKR3DR5WV3B
-          aws-region: 'us-east-1'
 
     - name: Set secrets to GH environment
       if: ${{ !env.ACT }} 
       uses: Bowery-RES/action-aws-secrets@v1.2
       with:
           secrets: |
-            Github/Cypress/User_Roles
-            Github/Cypress/Launch_Darkly
-            Github/Cypress/Data_Dog_Api_Key
-            Github/Cypress/Current_Dev_Record_Key
+            ${{ inputs.secret_name }}
           namespace: false
 
     - name: Run Cypress not snapshot tests on Currents.dev


### PR DESCRIPTION
Next changes:

- We're now store some of the secrets in AWS Secret Manager in order to expose them during action usage and make action much more easier to debug
- We don't need anymore to install Cypress globally since we're now using image with pre-installed Cypress
- Added condition whether we use this action in CI env or locally with act for better debugability

Example of CI run with updated action: https://github.com/Bowery-RES/webapp-ui-automation/runs/8134867513?check_suite_focus=true
![image](https://user-images.githubusercontent.com/80358262/187927825-e632b72f-9066-49a0-ab43-5b22445fde28.png)
